### PR TITLE
Exec documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Example 1:
 
 ```puppet
 telegraf::input { 'my_exec':
-  plugin_type => 'exec'
+  plugin_type => 'exec',
   options     => {
     'commands'    => ['/usr/local/bin/my_input.py',],
     'name_suffix' => '_my_input',


### PR DESCRIPTION
This patch fixes the Exec example adding the missing comma to provide valid syntax for the example.